### PR TITLE
FIX: Authentication issue with stage workaround

### DIFF
--- a/src/Extensions/PageHealthExtension.php
+++ b/src/Extensions/PageHealthExtension.php
@@ -52,12 +52,19 @@ class PageHealthExtension extends DataExtension
     /**
      * Gets the rendered html (current version, either draft or live)
      *
+     * @todo Solve authentication issue with ?stage=Stage
      * @return string|null
      */
     public function getRenderedHtml()
     {
         if (!$this->renderedHtml) {
-            $this->renderedHtml = file_get_contents($this->getOwner()->AbsoluteLink().'?stage=Stage');
+            $link = $this->getOwner()->AbsoluteLink();
+            
+            if (!$this->getOwner()->isPublished()) {
+                $link .='?stage=Stage';
+            }
+
+            $this->renderedHtml = file_get_contents($link);
         }
         
         if ($this->renderedHtml === false) {


### PR DESCRIPTION
When fetching from ?stage=Stage which, would obviously be ideal as anyone would like to know how it scores before it's published... we're presented with an authentication issue that is only logged in users are able to see ?stage=Stage whereas `file_get_contents()` doesn't allow that.

Moving forward, maybe we could tokenize an authenticated request using HTTPMiddleware and pass it along with the `file_get_contents` call.

Currently, with this; the "new page" bug is fixed; but will still display "Login" in the preview until the page is published.